### PR TITLE
CanvasAppの背景色を透明に設定可能に

### DIFF
--- a/src/display/canvasapp.js
+++ b/src/display/canvasapp.js
@@ -43,7 +43,11 @@ phina.namespace(function() {
     },
 
     _draw: function() {
-      this.canvas.clearColor(this.backgroundColor);
+      if (this.backgroundColor) {
+        this.canvas.clearColor(this.backgroundColor);
+      } else {
+        this.canvas.clear();
+      }
 
       if (this.currentScene.canvas) {
         this.currentScene._render();


### PR DESCRIPTION
CanvasAppのbackgroundColorプロパティに値が入っていない場合、Canvasをクリアするように修正しました。