### PR TITLE
phina.define()で未定義のクラスを継承したクラスを定義可能に

### DIFF
--- a/src/phina.js
+++ b/src/phina.js
@@ -145,13 +145,11 @@ phina.namespace(function() {
     if (params.superClass) {
       if (typeof params.superClass === 'string') {
         var _superClass = phina.using(params.superClass);
-        if (_superClass == null) {
-
-          var superDefine = phina.util.Flow(null, true);
-
-          _classDefinedCallback[params.superClass] = superDefine;
-
-          superDefine.then(function() {
+        if (typeof _superClass != 'function') {
+          if (_classDefinedCallback[params.superClass] == null) {
+            _classDefinedCallback[params.superClass] = [];
+          }
+          _classDefinedCallback[params.superClass].push(function() {
             phina.define(path, params);
           });
 
@@ -176,7 +174,10 @@ phina.namespace(function() {
     phina.register(path, _class);
     
     if (_classDefinedCallback[path]) {
-      _classDefinedCallback[path].resolve();
+      _classDefinedCallback[path].forEach(function(callback) {
+        callback();
+      });
+      _classDefinedCallback[path] = null;
     }
 
     return _class;

--- a/src/phina.js
+++ b/src/phina.js
@@ -132,6 +132,8 @@ phina.namespace(function() {
 
     return _class;
   });
+  
+  var _classDefinedCallback = {};
 
   /**
    * @member phina
@@ -142,7 +144,22 @@ phina.namespace(function() {
   phina.method('define', function(path, params) {
     if (params.superClass) {
       if (typeof params.superClass === 'string') {
-        params.superClass = phina.using(params.superClass);
+        var _superClass = phina.using(params.superClass);
+        if (_superClass == null) {
+
+          var superDefine = phina.util.Flow(null, true);
+
+          _classDefinedCallback[params.superClass] = superDefine;
+
+          superDefine.then(function() {
+            phina.define(path, params);
+          });
+
+          return ;
+        }
+        else {
+          params.superClass = _superClass;
+        }
       }
       else {
         params.superClass = params.superClass;
@@ -157,6 +174,10 @@ phina.namespace(function() {
     });
 
     phina.register(path, _class);
+    
+    if (_classDefinedCallback[path]) {
+      _classDefinedCallback[path].resolve();
+    }
 
     return _class;
   });


### PR DESCRIPTION
phina.defineでのクラス定義時、superClassに指定したクラスが未定義だった場合は、親クラスが定義されるまで子クラスの定義実行を待つように修正しました。
実装はtm.define()を参考にしています。