### PR TITLE
AssetLoader変数名違い修正

### DIFF
--- a/src/asset/assetloader.js
+++ b/src/asset/assetloader.js
@@ -52,7 +52,7 @@ phina.namespace(function() {
         },
         sound: function(path) {
           var sound = phina.asset.Sound();
-          var flow = audio.load(path);
+          var flow = sound.load(path);
           return flow;
         },
         spritesheet: function(path) {


### PR DESCRIPTION
AssetLoaderでSoundロード時の変数名に間違いがありましたので修正しました。