### PR TITLE
FrameAnimationで再生終了時nextが指定されてない場合の挙動追加

### DIFF
--- a/src/accessory/frameanimation.js
+++ b/src/accessory/frameanimation.js
@@ -67,7 +67,7 @@ phina.namespace(function() {
             return ;
           }
           else {
-            this.pause = true;
+            this.paused = true;
             this.finished = true;
             return ;
           }

--- a/src/accessory/frameanimation.js
+++ b/src/accessory/frameanimation.js
@@ -60,7 +60,8 @@ phina.namespace(function() {
             return ;
           }
           else {
-            // TODO: 
+            this.pause = true;
+            return ;
           }
         }
       }

--- a/src/accessory/frameanimation.js
+++ b/src/accessory/frameanimation.js
@@ -16,11 +16,18 @@ phina.namespace(function() {
 
       this.ss = phina.asset.AssetManager.get('spritesheet', ss);
       this.paused = true;
+      this.finished = false;
     },
 
     update: function() {
       if (this.paused) return ;
       if (!this.currentAnimation) return ;
+
+      if (this.finished) {
+        this.finished = false;
+        this.currentFrameIndex = 0;
+        return ;
+      }
 
       ++this.frame;
       if (this.frame%this.currentAnimation.frequency === 0) {
@@ -61,6 +68,7 @@ phina.namespace(function() {
           }
           else {
             this.pause = true;
+            this.finished = true;
             return ;
           }
         }


### PR DESCRIPTION
FrameAnimationでnextが指定されてない場合、アニメーション終了後に再生を止める様にしました。
pausedフラグをfalseにすると再度最初から再生されます。
確認よろしくお願いします。