### PR TITLE
RectangleShape と CircleShapeに塗りつぶし判定追加

### DIFF
--- a/src/display/shape.js
+++ b/src/display/shape.js
@@ -3,7 +3,7 @@ phina.namespace(function() {
 
   /**
    * @class phina.display.Shape
-   * 
+   *
    */
   phina.define('phina.display.Shape', {
     superClass: 'phina.display.CanvasElement',
@@ -30,7 +30,7 @@ phina.namespace(function() {
       this.fill = options.fill;
       this.stroke = options.stroke;
       this.strokeWidth = options.strokeWidth;
-      
+
       this.shadow = options.shadow;
       this.shadowBlur = options.shadowBlur;
 
@@ -146,7 +146,7 @@ phina.namespace(function() {
 
   /**
    * @class phina.display.RectangleShape
-   * 
+   *
    */
   phina.define('phina.display.RectangleShape', {
     superClass: 'phina.display.Shape',
@@ -172,14 +172,16 @@ phina.namespace(function() {
 
       this.canvas.transformCenter();
 
+      if (this.fill) {
+      　this.canvas.context.fillStyle = this.fill;
+      　this.canvas.fillRoundRect(-this.width/2, -this.height/2, this.width, this.height, this.cornerRadius);
+      ｝
+
       if (this.stroke) {
         this.canvas.context.lineWidth = this.strokeWidth;
         this.canvas.strokeStyle = this.stroke;
         this.canvas.strokeRoundRect(-this.width/2, -this.height/2, this.width, this.height, this.cornerRadius);
       }
-
-      this.canvas.context.fillStyle = this.fill;
-      this.canvas.fillRoundRect(-this.width/2, -this.height/2, this.width, this.height, this.cornerRadius);
     },
 
     _accessor: {
@@ -197,7 +199,7 @@ phina.namespace(function() {
 
   /**
    * @class phina.display.Shape
-   * 
+   *
    */
   phina.define('phina.display.CircleShape', {
     superClass: 'phina.display.Shape',
@@ -228,8 +230,10 @@ phina.namespace(function() {
         this.canvas.strokeCircle(0, 0, this.radius);
       }
 
-      this.canvas.context.fillStyle = this.fill;
-      this.canvas.fillCircle(0, 0, this.radius);
+      if (this.fill) {
+        this.canvas.context.fillStyle = this.fill;
+        this.canvas.fillCircle(0, 0, this.radius);
+      }
     },
 
     _accessor: {
@@ -245,4 +249,3 @@ phina.namespace(function() {
   });
 
 });
-

--- a/src/display/shape.js
+++ b/src/display/shape.js
@@ -224,15 +224,15 @@ phina.namespace(function() {
 
       this.canvas.transformCenter();
 
+      if (this.fill) {
+        this.canvas.context.fillStyle = this.fill;
+        this.canvas.fillCircle(0, 0, this.radius);
+      }
+
       if (this.stroke) {
         this.canvas.context.lineWidth = this.strokeWidth;
         this.canvas.strokeStyle = this.stroke;
         this.canvas.strokeCircle(0, 0, this.radius);
-      }
-
-      if (this.fill) {
-        this.canvas.context.fillStyle = this.fill;
-        this.canvas.fillCircle(0, 0, this.radius);
       }
     },
 

--- a/src/display/shape.js
+++ b/src/display/shape.js
@@ -173,8 +173,8 @@ phina.namespace(function() {
       this.canvas.transformCenter();
 
       if (this.fill) {
-      　this.canvas.context.fillStyle = this.fill;
-      　this.canvas.fillRoundRect(-this.width/2, -this.height/2, this.width, this.height, this.cornerRadius);
+        this.canvas.context.fillStyle = this.fill;
+        this.canvas.fillRoundRect(-this.width/2, -this.height/2, this.width, this.height, this.cornerRadius);
       ｝
 
       if (this.stroke) {

--- a/src/display/shape.js
+++ b/src/display/shape.js
@@ -175,7 +175,7 @@ phina.namespace(function() {
       if (this.fill) {
         this.canvas.context.fillStyle = this.fill;
         this.canvas.fillRoundRect(-this.width/2, -this.height/2, this.width, this.height, this.cornerRadius);
-      ｝
+      }
 
       if (this.stroke) {
         this.canvas.context.lineWidth = this.strokeWidth;
@@ -194,11 +194,10 @@ phina.namespace(function() {
         },
       }
     },
-
   });
 
   /**
-   * @class phina.display.Shape
+   * @class phina.display.CircleShape
    *
    */
   phina.define('phina.display.CircleShape', {


### PR DESCRIPTION
fill == null の場合、塗りつぶしをしないようにしました。
transparent指定せずに、枠だけのShapeを作ることができます。