### PR TITLE
shape.js draw内の変数宣言の順番を変更

### DIFF
--- a/src/display/shape.js
+++ b/src/display/shape.js
@@ -67,11 +67,11 @@ phina.namespace(function() {
       var image = this.canvas.domElement;
       // var x = -this.width*this.originX - this.padding;
       // var y = -this.height*this.originY - this.padding;
+      var w = image.width;
+      var h = image.height;
       var x = -w*this.origin.x;
       var y = -h*this.origin.y;
 
-      var w = image.width;
-      var h = image.height;
       canvas.context.drawImage(image,
         0, 0, w, h,
         x, y, w, h
@@ -499,4 +499,3 @@ phina.namespace(function() {
   });
 
 });
-


### PR DESCRIPTION
Shapeが表示されなかったので、変数宣言の順番を変更しました。

var w = image.width;
var h = image.height;

を先に宣言