### PR TITLE
CircleShapeのradiusプロパティ設定時にwidthとheightも併せて設定

### DIFF
--- a/src/display/shape.js
+++ b/src/display/shape.js
@@ -67,7 +67,7 @@ phina.namespace(function() {
       var image = this.canvas.domElement;
       var w = image.width;
       var h = image.height;
-      
+
       // var x = -this.width*this.originX - this.padding;
       // var y = -this.height*this.originY - this.padding;
       var x = -w*this.origin.x;
@@ -261,8 +261,10 @@ phina.namespace(function() {
           return this._radius;
         },
         set: function(v) {
-          this._dirtyDraw = true; this._radius = v;
-        },
+          this._dirtyDraw = true;
+          this._radius = v;
+          this._width = this._radius*2;
+          this._height = this._radius*2;
       }
     },
   });


### PR DESCRIPTION
CircleShapeのradiusを変えても_widthと_heightがデフォルトのサイズのままなので、_radius*2として、left、right、top、bottomが正しく機能するようにしました。
