### PR TITLE
EventDispathcerの別名メソッド

### DIFF
--- a/src/util/eventdispatcher.js
+++ b/src/util/eventdispatcher.js
@@ -94,7 +94,7 @@ phina.namespace(function() {
       dispatchEventByType: 'flare',
     };
     methodMap.forIn(function(old, name) {
-      phina.util.EventDispatcher.prototype[old] = phina.util.EventDispatcher.prototype[name];
+      phina.util.EventDispatcher.prototype.method(old, phina.util.EventDispatcher.prototype[name]);
     });
   })();
 

--- a/src/util/eventdispatcher.js
+++ b/src/util/eventdispatcher.js
@@ -82,4 +82,20 @@ phina.namespace(function() {
     },
   });
 
+
+  // 別名のメソッドを定義
+  (function() {
+    var methodMap = {
+      addEventListener: 'on',
+      removeEventListener: 'off',
+      clearEventListener: 'clear',
+      hasEventListener: 'has',
+      dispatchEvent: 'fire',
+      dispatchEventByType: 'flare',
+    };
+    methodMap.forIn(function(old, name) {
+      phina.util.EventDispatcher.prototype[old] = phina.util.EventDispatcher.prototype[name];
+    });
+  })();
+
 });


### PR DESCRIPTION
clearなどのメソッドは継承先で使われる可能性が高いので、古い名前(addEventListener)など別名でも定義しました。