### PR TITLE
asset のロード失敗時の対策

### DIFF
--- a/src/asset/asset.js
+++ b/src/asset/asset.js
@@ -8,6 +8,10 @@ phina.namespace(function() {
   phina.define('phina.asset.Asset', {
     superClass: "phina.util.EventDispatcher",
 
+    serverError: false,
+    notFound: false,
+    loadError: false,
+
     /**
      * @constructor
      */
@@ -33,6 +37,9 @@ phina.namespace(function() {
         resolve();
       }, 100);
     },
+
+    // ロード失敗時にダミーをセットする
+    loadDummy: function() { },
 
   });
 

--- a/src/asset/assetloader.js
+++ b/src/asset/assetloader.js
@@ -2,7 +2,7 @@
 phina.namespace(function() {
 
   /**
-   * @class phina.asset.AssetManager
+   * @class phina.asset.AssetLoader
    * 
    */
   phina.define('phina.asset.AssetLoader', {
@@ -33,19 +33,45 @@ phina.namespace(function() {
           var func = phina.asset.AssetLoader.assetLoadFunctions[type];
           var flow = func(key, value);
           flow.then(function(asset) {
+            if (self.cache) {
+              phina.asset.AssetManager.set(type, key, asset);
+            }
             self.flare('progress', {
               key: key,
               asset: asset,
               progress: (++counter/flows.length),
             });
-            if (self.cache) {
-              phina.asset.AssetManager.set(type, key, asset);
-            }
           });
           flows.push(flow);
         });
       });
 
+
+      if (self.cache) {
+
+        self.on('progress', function(e) {
+          if (e.progress >= 1.0) {
+            // load¸”sA‘Îô
+            params.forIn(function(type, assets) {
+              assets.forIn(function(key, value) {
+                var asset = phina.asset.AssetManager.get(type, key);
+                if (asset.loadError) {
+                  var dummy = phina.asset.AssetManager.get(type, 'dummy');
+                  if (dummy) {
+                    if (dummy.loadError) {
+                      dummy.loadDummy();
+                      dummy.loadError = false;
+                    }
+                    phina.asset.AssetManager.set(type, key, dummy);
+                  } else {
+                    asset.loadDummy();
+                  }
+                }
+              });
+            });
+          }
+        });
+      }
       return phina.util.Flow.all(flows).then(function(args) {
         self.flare('load');
       });

--- a/src/asset/assetloader.js
+++ b/src/asset/assetloader.js
@@ -51,7 +51,7 @@ phina.namespace(function() {
 
         self.on('progress', function(e) {
           if (e.progress >= 1.0) {
-            // load¸”sA‘Îô
+            // loadå¤±æ•—æ™‚ã€å¯¾ç­–
             params.forIn(function(type, assets) {
               assets.forIn(function(key, value) {
                 var asset = phina.asset.AssetManager.get(type, key);

--- a/src/asset/sound.js
+++ b/src/asset/sound.js
@@ -121,6 +121,7 @@ phina.namespace(function() {
       xml.onreadystatechange = function() {
         if (xml.readyState === 4) {
           if ([200, 201, 0].indexOf(xml.status) !== -1) {
+
             // 音楽バイナリーデータ
             var data = xml.response;
 
@@ -130,14 +131,33 @@ phina.namespace(function() {
               r(self);
             }, function() {
               console.warn("音声ファイルのデコードに失敗しました。(" + src + ")");
-              self.loaded = true;
               r(self);
+              self.flare('decodeerror');
             });
+
+          } else if (404 === xml.status) {
+            // not found
+
+            self.loadError = true;
+            self.notFound= true;
+            r(self);
+            self.flare('loaderror');
+            self.flare('notfound');
+
+          } else {
+            // サーバーエラー
+
+            self.loadError = true;
+            self.serverError = true;
+            r(self);
+            self.flare('loaderror');
+            self.flare('servererror');
           }
         }
       };
 
       xml.responseType = 'arraybuffer';
+
       xml.send(null);
     },
 
@@ -167,6 +187,10 @@ phina.namespace(function() {
         self.loaded = true;
         r(self);
       });
+    },
+
+    loadDummy: function() {
+      this.loadFromBuffer();
     },
 
     _accessor: {

--- a/src/asset/sound.js
+++ b/src/asset/sound.js
@@ -135,7 +135,7 @@ phina.namespace(function() {
               self.flare('decodeerror');
             });
 
-          } else if (404 === xml.status) {
+          } else if (xml.status === 404) {
             // not found
 
             self.loadError = true;

--- a/src/game/loadingscene.js
+++ b/src/game/loadingscene.js
@@ -57,26 +57,6 @@ phina.namespace(function() {
       }
 
       this.gauge.onfull = function() {
-        
-        // load失敗時、対策
-        options.assets.forIn(function(type, assets) {
-          assets.forIn(function(key, value) {
-            var asset = phina.asset.AssetManager.get(type, key);
-            if (asset.loadError) {
-              var dummy = phina.asset.AssetManager.get(type, 'dummy');
-              if (dummy) {
-                if (dummy.loadError) {
-                  dummy.loadDummy();
-                  dummy.loadError = false;
-                }
-                phina.asset.AssetManager.set(type, key, dummy);
-              } else {
-                asset.loadDummy();
-              }
-            }
-          });
-        });
-
         if (options.exitType === 'auto') {
           this.app.popScene();
         }

--- a/src/game/loadingscene.js
+++ b/src/game/loadingscene.js
@@ -52,11 +52,31 @@ phina.namespace(function() {
       }
       else {
         loader.onprogress = function(e) {
-          this.gauge.value = e.progress*100;
+          this.gauge.value = e.progress * 100;
         }.bind(this);
       }
 
       this.gauge.onfull = function() {
+        
+        // load失敗時、対策
+        options.assets.forIn(function(type, assets) {
+          assets.forIn(function(key, value) {
+            var asset = phina.asset.AssetManager.get(type, key);
+            if (asset.loadError) {
+              var dummy = phina.asset.AssetManager.get(type, 'dummy');
+              if (dummy) {
+                if (dummy.loadError) {
+                  dummy.loadDummy();
+                  dummy.loadError = false;
+                }
+                phina.asset.AssetManager.set(type, key, dummy);
+              } else {
+                asset.loadDummy();
+              }
+            }
+          });
+        });
+
         if (options.exitType === 'auto') {
           this.app.popScene();
         }


### PR DESCRIPTION
Asset クラスに loadDummy (ローカルだけで完結できるものをセットするための抽象メソッド)
Soundクラスの_loadでロード失敗時に失敗したフラグをセットし成功したことにするように変更。
LoadingSceneでゲージがいっぱいになったときロードに失敗しているアセットはダミーをセット

```javascript

assets:{
  sound:{
    dummy:'dummy.mp3',
    test:'test.mp3',
  }
}

```

みたいに アセットのキーを`'dummy'`にしたものがdummy読み込み用のアセットになります。
dummyがない場合は、loadDummyします。