### PR TITLE
テストが正しくなかったのを修正

### DIFF
--- a/test/common/src/geom/index.js
+++ b/test/common/src/geom/index.js
@@ -34,8 +34,7 @@ describe('#geom', function() {
         v.rotate((+1).toRadian());
 
         var deg = Math.abs(n - v.toAngle().toDegree());
-        if (359 <  deg) { deg -= 360; }
-        if (deg < -359) { deg += 360; }
+        if (359 < deg) { deg = (deg - 360).abs(); }
 
         assert(deg < 0.0001);
       });
@@ -45,8 +44,7 @@ describe('#geom', function() {
         v.rotate((-1).toRadian());
 
         var deg = Math.abs(n - v.toAngle().toDegree());
-        if (359 <  deg) { deg -= 360; }
-        if (deg < -359) { deg += 360; }
+        if (359 < deg) { deg = (deg - 360).abs(); }
 
         assert(deg < 0.0001);
       });


### PR DESCRIPTION
- 360度を引いた結果が負の数の場合に、判定が正しく行われない