### PR TITLE
Tweener　クラスにタイプの変更を追加 (更新方法をFPSでするかなど）

### DIFF
--- a/src/accessory/tweener.js
+++ b/src/accessory/tweener.js
@@ -10,6 +10,9 @@ phina.namespace(function() {
   phina.define('phina.accessory.Tweener', {
     superClass: 'phina.accessory.Accessory',
 
+    // update type
+    type : 'normal',
+
     /**
      * @constructor
      */
@@ -29,6 +32,11 @@ phina.namespace(function() {
 
     update: function(app) {
       this._update(app);
+    },
+
+    setType:function(type){
+      this.type = type;
+      return this;
     },
 
     to: function(props, duration, easing) {
@@ -267,8 +275,7 @@ phina.namespace(function() {
 
     _updateTween: function(app) {
       var tween = this._tween;
-      // var time = app.ticker.deltaTime;
-      var time = 1000/app.fps;
+      var time = this._getUnitTime(app);
 
       tween.forward(time);
       this.flare('tween');
@@ -282,7 +289,7 @@ phina.namespace(function() {
 
     _updateWait: function(app) {
       var wait = this._wait;
-      var time = app.ticker.deltaTime;
+      var time = this._getUnitTime(app);
       wait.time += time;
 
       if (wait.time >= wait.limit) {
@@ -291,6 +298,32 @@ phina.namespace(function() {
         this._update = this._updateTask;
       }
     },
+
+    _getUnitTime : function(app){
+      var func = this._static.getUnitTimeMap[this.type];
+      if (func) {
+        return func(app);
+      }
+      else {
+        return 1000 / app.fps;
+      }
+    },
+
+    _static: {
+      getUnitTimeMap: {
+        normal: function(app) {
+          return 1000 / app.fps;
+        },
+        delta: function(app) {
+          return app.ticker.deltaTime;
+        },
+
+        fps: function(app) {
+          return 1;
+        },
+
+      }
+    }
   });
 
   phina.app.Element.prototype.getter('tweener', function() {

--- a/src/accessory/tweener.js
+++ b/src/accessory/tweener.js
@@ -130,11 +130,11 @@ phina.namespace(function() {
     },
 
     fadeOut: function(duration, easing) {
-      return this.fade(0.0, duration, easing)
+      return this.fade(0.0, duration, easing);
     },
 
     fadeIn: function(duration, easing) {
-      return this.fade(1.0, duration, easing)
+      return this.fade(1.0, duration, easing);
     },
 
     /**
@@ -206,7 +206,7 @@ phina.namespace(function() {
       }
 
       json.tweens.each(function(t) {
-        var t = t.clone();
+        t = t.clone();
         var method = t.shift();
         this[method].apply(this, t);
       }, this);

--- a/src/accessory/tweener.js
+++ b/src/accessory/tweener.js
@@ -7,10 +7,10 @@ phina.namespace(function() {
    * @class phina.accessory.Tweener
    * Tweener
    */
-  phina.define('phina.accessory.Tweener', {
+  var Tweener = phina.define('phina.accessory.Tweener', {
     superClass: 'phina.accessory.Accessory',
 
-    updateType : 'normal',
+    updateType: 'normal',
 
     /**
      * @constructor
@@ -119,14 +119,14 @@ phina.namespace(function() {
     },
 
     moveTo: function(x, y, duration, easing) {
-      return this.to({x:x,y:y}, duration, easing);
+      return this.to({ x: x, y: y }, duration, easing);
     },
     moveBy: function(x, y, duration, easing) {
-      return this.by({x:x,y:y}, duration, easing);
+      return this.by({ x: x, y: y }, duration, easing);
     },
 
     fade: function(value, duration, easing) {
-      return this.to({alpha:value}, duration, easing);
+      return this.to({ alpha: value }, duration, easing);
     },
 
     fadeOut: function(duration, easing) {
@@ -219,7 +219,7 @@ phina.namespace(function() {
     },
 
     _updateTask: function(app) {
-      if (!this.playing) return ;
+      if (!this.playing) return;
 
       var task = this._tasks[this._index];
       if (!task) {
@@ -230,7 +230,7 @@ phina.namespace(function() {
         else {
           this.playing = false;
         }
-        return ;
+        return;
       }
       else {
         ++this._index;
@@ -239,7 +239,7 @@ phina.namespace(function() {
       if (task.type === 'tween') {
         this._tween = phina.util.Tween();
 
-        var duration = task.duration || this._static.DEFAULT_UNIT_TIME_MAP[this.updateType] || 1000;
+        var duration = task.duration || this._getDefaultDuration();
         if (task.mode === 'to') {
           this._tween.to(this.target, task.props, duration, task.easing);
         }
@@ -299,38 +299,49 @@ phina.namespace(function() {
       }
     },
 
-    _getUnitTime : function(app){
-      var func = this._static.UNIT_TIME_FUNCTION_MAP[this.updateType];
-      if (func) {
-        return func(app);
+    _getUnitTime: function(app) {
+      var obj = UPDATE_MAP[this.updateType];
+      if (obj) {
+        return obj.func(app);
       }
       else {
         return 1000 / app.fps;
       }
     },
 
+    _getDefaultDuration: function() {
+      var obj = UPDATE_MAP[this.updateType];
+      return obj && obj.duration;
+    },
+
     _static: {
-      UNIT_TIME_FUNCTION_MAP: {
-        normal: function(app) {
-          return 1000 / app.fps;
-        },
-        delta: function(app) {
-          return app.ticker.deltaTime;
-        },
-
-        fps: function(app) {
-          return 1;
+      UPDATE_MAP: {
+        normal: {
+          func: function(app) {
+            return 1000 / app.fps;
+          },
+          duration: 1000,
         },
 
-      },
+        delta: {
+          func: function(app) {
+            return app.ticker.deltaTime;
+          },
+          duration: 1000,
+        },
 
-      DEFAULT_UNIT_TIME_MAP: {
-        normal: 1000,
-        delta: 1000,
-        fps: 30,
-      },
+        fps: {
+          func: function(app) {
+            return 1;
+          },
+          duration: 30,
+        },
+
+      }
     }
   });
+
+  var UPDATE_MAP = Tweener.UPDATE_MAP;
 
   phina.app.Element.prototype.getter('tweener', function() {
     if (!this._tweener) {

--- a/src/accessory/tweener.js
+++ b/src/accessory/tweener.js
@@ -299,7 +299,7 @@ phina.namespace(function() {
     },
 
     _getUnitTime : function(app){
-      var func = this._static.getUnitTimeMap[this.updateType];
+      var func = this._static.UNIT_TIME_FUNCTION_MAP[this.updateType];
       if (func) {
         return func(app);
       }
@@ -309,7 +309,7 @@ phina.namespace(function() {
     },
 
     _static: {
-      getUnitTimeMap: {
+      UNIT_TIME_FUNCTION_MAP: {
         normal: function(app) {
           return 1000 / app.fps;
         },
@@ -321,7 +321,8 @@ phina.namespace(function() {
           return 1;
         },
 
-      }
+      },
+
     }
   });
 

--- a/src/accessory/tweener.js
+++ b/src/accessory/tweener.js
@@ -10,8 +10,7 @@ phina.namespace(function() {
   phina.define('phina.accessory.Tweener', {
     superClass: 'phina.accessory.Accessory',
 
-    // update type
-    type : 'normal',
+    updateType : 'normal',
 
     /**
      * @constructor
@@ -34,8 +33,8 @@ phina.namespace(function() {
       this._update(app);
     },
 
-    setType:function(type){
-      this.type = type;
+    setUpdateType: function(type) {
+      this.updateType = type;
       return this;
     },
 
@@ -300,7 +299,7 @@ phina.namespace(function() {
     },
 
     _getUnitTime : function(app){
-      var func = this._static.getUnitTimeMap[this.type];
+      var func = this._static.getUnitTimeMap[this.updateType];
       if (func) {
         return func(app);
       }

--- a/src/accessory/tweener.js
+++ b/src/accessory/tweener.js
@@ -239,14 +239,15 @@ phina.namespace(function() {
       if (task.type === 'tween') {
         this._tween = phina.util.Tween();
 
+        var duration = task.duration || this._static.DEFAULT_UNIT_TIME_MAP[this.updateType] || 1000;
         if (task.mode === 'to') {
-          this._tween.to(this.target, task.props, task.duration, task.easing);
+          this._tween.to(this.target, task.props, duration, task.easing);
         }
         else if (task.mode === 'by') {
-          this._tween.by(this.target, task.props, task.duration, task.easing);
+          this._tween.by(this.target, task.props, duration, task.easing);
         }
         else {
-          this._tween.from(this.target, task.props, task.duration, task.easing);
+          this._tween.from(this.target, task.props, duration, task.easing);
         }
         this._update = this._updateTween;
         this._update(app);
@@ -323,6 +324,11 @@ phina.namespace(function() {
 
       },
 
+      DEFAULT_UNIT_TIME_MAP: {
+        normal: 1000,
+        delta: 1000,
+        fps: 30,
+      },
     }
   });
 

--- a/src/accessory/tweener.js
+++ b/src/accessory/tweener.js
@@ -219,7 +219,7 @@ phina.namespace(function() {
     },
 
     _updateTask: function(app) {
-      if (!this.playing) return;
+      if (!this.playing) return ;
 
       var task = this._tasks[this._index];
       if (!task) {
@@ -230,7 +230,7 @@ phina.namespace(function() {
         else {
           this.playing = false;
         }
-        return;
+        return ;
       }
       else {
         ++this._index;


### PR DESCRIPTION
issue　#52 
対応
_getUnitTime(app) タイプに合わせた時間を取得　想定外のタイプの場合は1000/app.fps
_static: getUnitTimeMap{} タイプに合わせた時間を取得するための関数が入ったオブジェクト
setType(type) メソッドチェーン

FPSのTweenerが早く欲しかったのでとりあえず実装してみました。