### PR TITLE
フレームアニメーションのサイズを反映させるかどうかをフラグで分岐

### DIFF
--- a/src/accessory/frameanimation.js
+++ b/src/accessory/frameanimation.js
@@ -21,6 +21,7 @@ phina.namespace(function() {
       this.ss = phina.asset.AssetManager.get('spritesheet', ss);
       this.paused = true;
       this.finished = false;
+      this.fit = true;
     },
 
     update: function() {
@@ -82,6 +83,10 @@ phina.namespace(function() {
       var frame = this.ss.getFrame(index);
       this.target.srcRect.set(frame.x, frame.y, frame.width, frame.height);
 
+      if (this.fit) {
+        this.target.width = frame.width;
+        this.target.height = frame.height;
+      }
     },
   });
 });

--- a/src/app/scene.js
+++ b/src/app/scene.js
@@ -8,15 +8,17 @@ phina.namespace(function() {
       this.superInit();
     },
 
-    exit: function(params) {
+    exit: function(nextLabel, nextArguments) {
       if (!this.app) return ;
 
-      if (typeof params !== 'object') {
-        this.nextLabel = arguments[0];
-        this.nextArguments = arguments[1];
-      }
-      else if (params) {
-        this.nextArguments = params;
+      if (arguments.length > 0) {
+        if (typeof arguments[0] === 'object') {
+          nextLabel = arguments[0].nextLabel || this.nextLabel;
+          nextArguments = arguments[0];
+        }
+
+        this.nextLabel = nextLabel;
+        this.nextArguments = nextArguments;
       }
 
       this.app.popScene();


### PR DESCRIPTION
後方互換が軒並み死ぬので一旦 fit フラグを持たせてデフォルト true にしました.

下記のようにすれば勝手に fit しなくなります.

```
fa.fit = false;
elm.width = 128;
elm.height = 128;
```