### PR TITLE
Hotfix/pathshape

### DIFF
--- a/src/display/shape.js
+++ b/src/display/shape.js
@@ -411,7 +411,7 @@ phina.namespace(function () {
       return this;
     },
 
-    clearColor: function () {
+    clear: function () {
       this.paths.length = 0;
       this._dirtyDraw = true;
       return this;
@@ -452,7 +452,7 @@ phina.namespace(function () {
         };
       }
       var maxX = -Infinity;
-      var maxY = -Infinity
+      var maxY = -Infinity;
       var minX = Infinity;
       var minY = Infinity;
 

--- a/src/display/shape.js
+++ b/src/display/shape.js
@@ -447,8 +447,8 @@ phina.namespace(function () {
       var paths = this.paths;
       if (paths.length === 0) {
         return {
-          width: 0,
-          height:0,
+          width: this.padding * 2,
+          height:this.padding * 2,
         };
       }
       var maxX = -Infinity;


### PR DESCRIPTION
パスがないときにpaddingを忘れてたのを修正

余談ですが、canvasでサイズ(width or height)が0なものを描画するとSafariやFirefoxではエラーになるようですね。