### PR TITLE
AssetLoader の spritesheet をソースに直接書いて読み込む場合に発生するバグを修正しました

### DIFF
--- a/src/asset/assetloader.js
+++ b/src/asset/assetloader.js
@@ -27,7 +27,11 @@ phina.namespace(function() {
       var flows = [];
 
       var counter = 0;
-
+      var length = 0;
+      params.forIn(function(type, assets) {
+        length += Object.keys(assets).length;
+      });
+      
       params.forIn(function(type, assets) {
         assets.forIn(function(key, value) {
           var func = phina.asset.AssetLoader.assetLoadFunctions[type];
@@ -39,7 +43,7 @@ phina.namespace(function() {
             self.flare('progress', {
               key: key,
               asset: asset,
-              progress: (++counter/flows.length),
+              progress: (++counter/length),
             });
           });
           flows.push(flow);

--- a/test/game/src/asset.js
+++ b/test/game/src/asset.js
@@ -191,5 +191,57 @@ th.describe("asset.AssetLoader", function() {
       console.log(e);
     };
   });
+  th.it('local_spritesheet', function() {
+    var loader = phina.asset.AssetLoader();
+    var flow = loader.load({
+      image: {
+        'tomapiko': '../../assets/images/character/tomapiyo.png',
+      },
+      spritesheet: {
+        ss: {
+         "frame": {
+           "width": 64,
+           "height": 64,
+           "cols": 6,
+           "rows": 3,
+         },
+         // アニメーション
+         "animations" : {
+           "down": {
+             "frames": [6,7,8,7],
+             "next": "down",
+             "frequency": 5,
+           },
+         },
+        
+        },
+      },
+    });
 
+    var logLabel = phina.display.Label({
+      text: '# Loaded\n',
+      align: 'left',
+    }).addChildTo(this);
+    logLabel.x = 100;
+    logLabel.y = 200;
+
+    flow.then(function() {
+      var elm = phina.display.Sprite('tomapiko').addChildTo(this);
+      elm.x = 320;
+      elm.y = 480;
+      var anim = phina.accessory.FrameAnimation('ss');
+      anim.attachTo(elm);
+      anim.gotoAndPlay('down');
+      
+      this.onpointstart = function(app) {
+        elm.x = app.pointer.x;
+        elm.y = app.pointer.y;
+      };
+    }.bind(this));
+
+    loader.onprogress = function(e) {
+      logLabel.text += '- ' + e.key + '\n';
+      console.log(e);
+    };
+  });
 });


### PR DESCRIPTION
progressが count/flows.length になってるが、直接書いてあるspritesheetの場合flow.thenが即時発生するためprogressが1になることがあり、その結果、LoadingSceneで読み込みか完了する前に次のシーンへ遷移してしますという現象を修正しました。