### PR TITLE
Array.fromの挙動を修正しました

### DIFF
--- a/src/core/array.js
+++ b/src/core/array.js
@@ -694,8 +694,8 @@
   Array.$method("from", function(arrayLike, callback, context) {
     if (!Object(arrayLike).length) return [];
 
+    var result = [];
     if (Symbol && Symbol.iterator && arrayLike[Symbol.iterator]) {
-        var result = [];
         var iterator = arrayLike[Symbol.iterator]();
         while (true) {
             var iteratorResult = iterator.next();
@@ -707,7 +707,10 @@
         return result;
     }
 
-    return Array.prototype.map.call(arrayLike, typeof callback == 'function' ? callback : function(item) {
+    for (var i = 0, len = arrayLike.length; i < len; i++) {
+        result.push(arrayLike[i]);
+    }
+    return result.map(typeof callback == 'function' ? callback : function(item) {
       return item;
     }, context);
   });

--- a/src/core/array.js
+++ b/src/core/array.js
@@ -700,7 +700,9 @@
         while (true) {
             var iteratorResult = iterator.next();
             if (iteratorResult.done) break;
-            result.push(iteratorResult.value);
+
+            var value = typeof callback === 'function' ? callback.bind(context || this)(iteratorResult.value) : iteratorResult.value;
+            result.push(value);
         }
         return result;
     }

--- a/src/core/array.js
+++ b/src/core/array.js
@@ -673,10 +673,13 @@
   /**
    * @method from
    * @static
-   * ES6 準拠の from 関数です。array-like オブジェクトから新しい配列を生成します。
+   * ES6 準拠の from 関数です。array-like オブジェクトかiterable オブジェクトから新しい配列を生成します。
    *
-   * array-like オブジェクトとは、length プロパティを持ち、数字の添字でアクセス可能なオブジェクトのことです。  
+   * array-like オブジェクトとは、length プロパティを持ち、数字の添字でアクセス可能なオブジェクトのことです。
    * 通常の配列のほか、String、arguments、NodeList なども array-like オブジェクトです。
+   *
+   * iterable オブジェクトとは、Symbol.iterator プロパティを持つオブジェクトのことです。
+   * 通常の配列のほか、String、arguments、NodeList なども iterable オブジェクトです。
    *
    * ### Example
    *     Array.from([1, 2, 3], function(elm){ return elm * elm} ); // => [1, 4, 9]
@@ -690,6 +693,17 @@
    */
   Array.$method("from", function(arrayLike, callback, context) {
     if (!Object(arrayLike).length) return [];
+
+    if (Symbol && Symbol.iterator && arrayLike[Symbol.iterator]) {
+        var result = [];
+        var iterator = arrayLike[Symbol.iterator]();
+        while (true) {
+            var iteratorResult = iterator.next();
+            if (iteratorResult.done) break;
+            result.push(iteratorResult.value);
+        }
+        return result;
+    }
 
     return Array.prototype.map.call(arrayLike, typeof callback == 'function' ? callback : function(item) {
       return item;

--- a/test/common/src/core/array.js
+++ b/test/common/src/core/array.js
@@ -175,6 +175,7 @@ describe('#Array', function() {
   it('from', function() {
     assert(Array.from("foo").equals(['f', 'o', 'o']));
     assert(Array.from("😉😉😉").equals(['😉', '😉', '😉']));
+    assert(Array.from([1, 2, 3], function(v) {return v * v}).equals([1, 4, 9]));
   });
   
   it('most', function() {

--- a/test/common/src/core/array.js
+++ b/test/common/src/core/array.js
@@ -176,6 +176,7 @@ describe('#Array', function() {
     assert(Array.from("foo").equals(['f', 'o', 'o']));
     assert(Array.from("😉😉😉").equals(['😉', '😉', '😉']));
     assert(Array.from([1, 2, 3], function(v) {return v * v}).equals([1, 4, 9]));
+    assert(Array.from({length: 3}, function(_, i) {return i}).equals([0, 1, 2]));
   });
   
   it('most', function() {

--- a/test/common/src/core/array.js
+++ b/test/common/src/core/array.js
@@ -174,6 +174,7 @@ describe('#Array', function() {
 
   it('from', function() {
     assert(Array.from("foo").equals(['f', 'o', 'o']));
+    assert(Array.from("😉😉😉").equals(['😉', '😉', '😉']));
   });
   
   it('most', function() {


### PR DESCRIPTION
はじめまして、Remewと言います。

突然ではありますが、phina.jsのソースコードを眺めていて発見したバグを修正したので、プルリクエストを送ります。

具体的には、Array.fromの挙動がES6とは違う部分があったので、それを修正しました。
例えば、サロゲートペアを含む文字列を引数に与えると1文字ずつの配列ではなく化けた文字が含まれた配列が返ってきたりなどです。

まだプルリクエストに不慣れなので、何か不手際があったら申し訳ありません。
それでは、よろしくお願いします。
