### PR TITLE
[phina.display.Sprite] setImage関数内のthis.frameIndexの位置変更

### DIFF
--- a/src/display/sprite.js
+++ b/src/display/sprite.js
@@ -38,10 +38,10 @@ phina.namespace(function() {
       this.width = this._image.domElement.width;
       this.height = this._image.domElement.height;
 
-      this.frameIndex = 0;
-
       if (width) { this.width = width; }
       if (height) { this.height = height; }
+
+      this.frameIndex = 0;
 
       return this;
     },


### PR DESCRIPTION
画像の切り出しサイズにデフォルトの64x64以外のサイズを指定した場合、width, heightを指定した後にthis.frameIndex = 0 を呼び出さないと、全体の画像サイズで表示されてしまいます。