### PR TITLE
requestAnimationFrame 対応

### DIFF
--- a/src/accessory/tweener.js
+++ b/src/accessory/tweener.js
@@ -10,7 +10,7 @@ phina.namespace(function() {
   var Tweener = phina.define('phina.accessory.Tweener', {
     superClass: 'phina.accessory.Accessory',
 
-    updateType: 'normal',
+    updateType: 'delta',
 
     /**
      * @constructor

--- a/src/display/canvasapp.js
+++ b/src/display/canvasapp.js
@@ -20,6 +20,9 @@ phina.namespace(function() {
           document.body.appendChild(options.domElement);
         }
       }
+      if(!options.runner && phina.isAndroid()) {
+        options.runner = phina.global.requestAnimationFrame;
+      }
       this.superInit(options);
 
 

--- a/src/display/domapp.js
+++ b/src/display/domapp.js
@@ -32,7 +32,7 @@ phina.namespace(function() {
       }
       
       if(typeof options.runner === 'function') {
-        this.ticker.runner = runner;
+        this.ticker.runner = options.runner;
       }
 
       this.mouse = phina.input.Mouse(this.domElement);

--- a/src/display/domapp.js
+++ b/src/display/domapp.js
@@ -30,6 +30,10 @@ phina.namespace(function() {
       if (options.fps !== undefined) {
         this.fps = options.fps;
       }
+      
+      if(typeof options.runner === 'function') {
+        this.ticker.runner = runner;
+      }
 
       this.mouse = phina.input.Mouse(this.domElement);
       this.touch = phina.input.Touch(this.domElement);

--- a/src/phina.js
+++ b/src/phina.js
@@ -41,15 +41,58 @@ var phina = phina || {};
     },
   });
 
+  
+  /**
+   * @method testUA
+   * UAを正規表現テスト
+   */
+  phina.$method('testUA', function(regExp) {
+    if (!phina.global.navigator) return false;
+    var ua = phina.global.navigator.userAgent;
+    return regExp.test(ua);
+  });
+
+  /**
+   * @method isAndroid
+   * Android かどうかをチェック
+   */
+  phina.$method('isAndroid', function() {
+    return phina.testUA(/Android/);
+  });
+  
+  /**
+   * @method isIPhone
+   * iPhone かどうかをチェック
+   */
+  phina.$method('isIPhone', function() {
+    return phina.testUA(/iPhone/);
+  });
+  
+  /**
+   * @method isIPad
+   * iPad かどうかをチェック
+   */
+  phina.$method('isIPad', function() {
+    return phina.testUA(/iPad/);
+  });
+  
+  /**
+   * @method isIOS
+   * iOS かどうかをチェック
+   */
+  phina.$method('isIOS', function() {
+    return phina.testUA(/iPhone|iPad/);
+  });
+
   /**
    * @method isMobile
    * mobile かどうかをチェック
    */
   phina.$method('isMobile', function() {
-    if (!phina.global.navigator) return false;
-    var ua = phina.global.navigator.userAgent;
-    return (ua.indexOf("iPhone") > 0 || ua.indexOf("iPad") > 0 || ua.indexOf("Android") > 0);
+    return phina.testUA(/iPhone|iPad|Android/);
   });
+  
+  
 
 
   // support node.js

--- a/src/util/ticker.js
+++ b/src/util/ticker.js
@@ -59,10 +59,10 @@
       var self = this;
 
       this.startTime = this.currentTime = (new Date()).getTime();
-
+      var runner = self.runner;
       var fn = function() {
         var delay = self.run();
-        self.runner(fn, delay);
+        runner(fn, delay);
       };
       fn();
 

--- a/src/util/ticker.js
+++ b/src/util/ticker.js
@@ -25,6 +25,7 @@
       this.frame = 0;
       this.deltaTime = 0;
       this.elapsedTime = 0;
+      this.runner = phina.util.Ticker.runner;
     },
 
     tick: function(func) {
@@ -61,7 +62,7 @@
 
       var fn = function() {
         var delay = self.run();
-        setTimeout(fn, delay);
+        self.runner(fn, delay);
       };
       fn();
 
@@ -89,6 +90,13 @@
         },
       },
     },
+    
+    _static: {
+      runner: function(run, delay) {
+        setTimeout(run, delay);
+      },
+    },
+    
   });
 
 })();


### PR DESCRIPTION
- UAの判定の強化、拡張
- Tickerのループに使う関数を任意でセットする機能の実装(ticker.runner)
- TweenerのupdateTypeのデフォルトを `'normal'` から `'delta'`に変更

Androidのみrunnerを指定しない場合はrequestAnimationFrameになるようにしました。
タッチで一瞬止まる問題は解消しました。

任意でセットすることも可能

```js

DomApp({runner:requestAnimationFrame})
CanvasApp({runner:requestAnimationFrame})
GameApp({runner:requestAnimationFrame})

```

self.runner()で呼び出していないのは https://github.com/phi-jp/phina.js/commit/1258769fdf08087ad41f5ff0def0076c4fbe375e
Illegal invocation 対策のため
これはthisとなるオブジェクトが想定外の場合に出るエラー
